### PR TITLE
BugFix

### DIFF
--- a/lib/jsonrpc2/server/handler.ex
+++ b/lib/jsonrpc2/server/handler.ex
@@ -74,6 +74,9 @@ defmodule JSONRPC2.Server.Handler do
 
       {:error, _error} ->
         standard_error_response(:parse_error, nil)
+
+      {:error, :invalid, _number} ->
+        standard_error_response(:parse_error, nil)
     end
     |> encode_response(module, serializer, json)
   end


### PR DESCRIPTION
The decoder sometimes returns a triplet that is not handled by the handle function